### PR TITLE
Bintray Repository Shutdown breaks build

### DIFF
--- a/lottery-web3j-app/pom.xml
+++ b/lottery-web3j-app/pom.xml
@@ -59,6 +59,7 @@
       <plugin>
         <groupId>org.web3j</groupId>
         <artifactId>web3j-maven-plugin</artifactId>
+        <version>4.6.5</version>
         <configuration>
           <packageName>org.sgitario.quarkus.model</packageName>
           <nativeJavaType>true</nativeJavaType>


### PR DESCRIPTION
Following the commands in the related website article the Maven build fails

```
[ERROR] Failed to execute goal org.web3j:web3j-maven-plugin:4.5.11:generate-sources (default) on project lottery-web3j-app: Execution default of goal org.web3j:web3j-maven-plugin:4.5.11:generate-sources failed: Plugin org.web3j:web3j-maven-plugin:4.5.11 or one of its dependencies could not be resolved: Failed to collect dependencies at org.web3j:web3j-maven-plugin:jar:4.5.11 -> org.ethereum:solcJ-all:jar:0.5.7: Failed to read artifact descriptor for org.ethereum:solcJ-all:jar:0.5.7: Could not transfer artifact org.ethereum:solcJ-all:pom:0.5.7 from/to ethereum (https://dl.bintray.com/ethereum/maven/): authorization failed for https://dl.bintray.com/ethereum/maven/org/ethereum/solcJ-all/0.5.7/solcJ-all-0.5.7.pom, status: 403 Forbidden -> [Help 1]
```

Based on https://github.com/web3j/web3j-maven-plugin/issues/65 the mentioned Bintray repository shut down in May 21.

A comment in the linked web3j-maven-plugin issue recommends to use a newer version of the plugin which allows the Quarkus build to succeed again.